### PR TITLE
Super basic partial sorting

### DIFF
--- a/backEnd/api/documents.py
+++ b/backEnd/api/documents.py
@@ -76,3 +76,19 @@ def sort(sortCriteria, ascending):
             None, 404, {'Content-Type': 'application/json'})
 
     return response
+
+
+@doc_bp.route('/search/<string:query>', methods=['GET'])
+def search(query):
+    if(db):
+        docs = db.search_docs(query)
+        for d in docs:
+            d['_id'] = str(d['_id'])
+        docs = json.dumps(docs)
+        response = make_response(
+            docs, 200, {'Content-Type': 'application/json'})
+    else:
+        response = make_response(
+            None, 404, {'Content-Type': 'application/json'})
+
+    return response

--- a/backEnd/database.py
+++ b/backEnd/database.py
@@ -29,6 +29,10 @@ class Database:
         doc = self.docs.find(query)
         return doc
 
+    def search_docs(self, query):
+        # stubbed for now - looking into libraries for partial search
+        return list(self.docs.find({'title': query}))
+
     def get_all_docs(self):
         # If we make this larger, we will remove the list() and just leave it as a cursor
         return list(self.docs.find())

--- a/backEnd/database.py
+++ b/backEnd/database.py
@@ -31,7 +31,15 @@ class Database:
 
     def search_docs(self, query):
         # stubbed for now - looking into libraries for partial search
-        return list(self.docs.find({'title': query}))
+        results = []
+        docs = list(self.docs.find())
+        for doc in docs:
+            if query in str(doc['title']):
+                results.append(doc)
+        if len(results) != 0:
+            return results
+        else:
+            return docs
 
     def get_all_docs(self):
         # If we make this larger, we will remove the list() and just leave it as a cursor

--- a/frontEnd/src/App.tsx
+++ b/frontEnd/src/App.tsx
@@ -31,12 +31,17 @@ export default class App extends Component<any, IAppState> {
 
   public async sort(sortBy: SortBy): Promise<void> {
     let docs = await this.documentService.sortDocuments(sortBy)
-    this.setState({documents: docs})
+    this.setState({ documents: docs })
+  }
+
+  public async search(query: string): Promise<void> {
+    let docs = await this.documentService.searchDocuments(query)
+    this.setState({ documents: docs })
   }
 
   public async loadDocuments() {
-	let documents = await this.documentService.getDocuments();
-	this.setState({documents: documents})
+    let documents = await this.documentService.getDocuments();
+    this.setState({ documents: documents })
   }
 
   render(): JSX.Element {
@@ -51,7 +56,7 @@ export default class App extends Component<any, IAppState> {
               key={document.uniqueID}
               render={() => (
                 <div>
-                  <Header sort={this.sort.bind(this)} />
+                  <Header sort={this.sort.bind(this)} search={this.search.bind(this)} />
                   <div className={styles.App}>
                     <DocumentPage document={document} />
                   </div>
@@ -65,7 +70,7 @@ export default class App extends Component<any, IAppState> {
           path={"/"}
           render={() => (
             <div>
-              <Header sort={this.sort.bind(this)} />
+              <Header sort={this.sort.bind(this)} search={this.search.bind(this)} />
               <div className={styles.App}>
                 <br />
                 <Container className={styles.AppDocuments}>

--- a/frontEnd/src/components/header/Header.tsx
+++ b/frontEnd/src/components/header/Header.tsx
@@ -10,7 +10,8 @@ import { BrowserRouter, Link, Route } from "react-router-dom";
 import SortBy from "../../model/SortBy";
 
 interface IHeaderProps {
-	sort: (sortBy: SortBy) => Promise<void>;
+  sort: (sortBy: SortBy) => Promise<void>;
+  search: (query: string) => Promise<void>;
 }
 
 export default class Header extends Component<IHeaderProps> {
@@ -33,7 +34,7 @@ export default class Header extends Component<IHeaderProps> {
         <Navbar.Toggle aria-controls="basic-navbar-nav" />
         <Navbar.Collapse id="basic-navbar-nav" />
         <Nav className="mr-auto">
-          <SearchBar />
+          <SearchBar search={this.props.search} />
           <FilterDropdown />
           <SortDropdown sort={this.props.sort} />
         </Nav>

--- a/frontEnd/src/components/header/SearchBar.tsx
+++ b/frontEnd/src/components/header/SearchBar.tsx
@@ -4,16 +4,35 @@ import FormControl from "react-bootstrap/FormControl";
 import Button from "react-bootstrap/Button";
 import styles from "./SearchBar.module.scss";
 
-export default class SearchBar extends Component {
+interface ISearchBarState {
+  query: string;
+}
+
+interface ISearchBarProps {
+  search: (query: string) => Promise<void>;
+}
+
+
+export default class SearchBar extends Component<ISearchBarProps, ISearchBarState> {
+
+  constructor(props: any) {
+    super(props);
+    this.state = {
+      query: ""
+    };
+  }
+
   render() {
     return (
       <Form inline className={styles.searchPadding}>
         <FormControl
-          type="text"
+          type="query"
           placeholder="Search by title, etc."
-          className = {styles.searchBar}
+          className={styles.searchBar}
+          onChange={(event) => this.setState({ query: event.target.value })}
         />
-        <Button variant="outline-info" className={styles.SearchButton}>
+        <Button variant="outline-info" className={styles.SearchButton} onClick={() => { this.props.search(this.state.query) }}
+          href={"#search/" + this.state.query}>
           Search
         </Button>
       </Form>

--- a/frontEnd/src/services/documentService/IDocumentService.ts
+++ b/frontEnd/src/services/documentService/IDocumentService.ts
@@ -4,4 +4,5 @@ import SortBy from "../../model/SortBy";
 export default interface IDocumentService {
 	getDocuments(): Promise<LitDocument[]>;
 	sortDocuments(sortBy: SortBy): Promise<LitDocument[]>;
+	searchDocuments(query: string): Promise<LitDocument[]>;
 }

--- a/frontEnd/src/services/documentService/LocalDocumentService.ts
+++ b/frontEnd/src/services/documentService/LocalDocumentService.ts
@@ -33,4 +33,24 @@ export default class LocalDocumentService implements IDocumentService {
     });
     return new Promise((resolve, reject) => resolve(documents));
   }
+
+  public async searchDocuments(query: string): Promise<LitDocument[]> {
+    let documents = await (await fetch(
+      "http://localhost:3000/search/" + query, {
+      mode: 'no-cors', headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+      }
+    })).json();
+    console.log(documents);
+    documents = documents.map(document => {
+      return new LitDocument(
+        document._id,
+        document.author,
+        document.text,
+        document.title
+      );
+    });
+    return new Promise((resolve, reject) => resolve(documents));
+  }
 }

--- a/frontEnd/src/services/documentService/TestDocumentService.ts
+++ b/frontEnd/src/services/documentService/TestDocumentService.ts
@@ -4,9 +4,13 @@ import LitDocument from "../../model/LitDocument";
 import SortBy from "../../model/SortBy";
 
 export default class TestDocumentService implements IDocumentService {
-	public async sortDocuments(sortBy: SortBy): Promise<LitDocument[]> {
-		return this.getDocuments();
-	}
+  public async sortDocuments(sortBy: SortBy): Promise<LitDocument[]> {
+    return this.getDocuments();
+  }
+
+  public async searchDocuments(query: string): Promise<LitDocument[]> {
+    return this.getDocuments();
+  }
 
   public async getDocuments(): Promise<LitDocument[]> {
     let documents = [


### PR DESCRIPTION
SUPER basic partial sorting. 
Next steps:

1. Making toast message/determining behavior when query has no results. For now, if query has no results, all documents remain shown.
2.  Searching is only by title currently. Searching by other fields, like Metadata must be added.
3. When search results appear, they are rendered weirdly because of the assumption 3 DocumentPreviews exist per row. This needs to be fixed.